### PR TITLE
Do not show unnamed tracks in text and raise attention point to coupler height

### DIFF
--- a/DVDispatcherMod/DVDispatcherMod.csproj
+++ b/DVDispatcherMod/DVDispatcherMod.csproj
@@ -92,6 +92,8 @@
     <Compile Include="DebugOutputJobWriter.cs" />
     <Compile Include="DispatcherHintManagers\DispatcherHintManager.cs" />
     <Compile Include="DispatcherHintManagers\NonVRDispatchHintManagerFactory.cs" />
+    <Compile Include="DispatcherHints\AdjacentCarsCenterFinder.cs" />
+    <Compile Include="DispatcherHints\AdjacentCarsGrouper.cs" />
     <Compile Include="DispatcherHints\DispatcherHint.cs" />
     <Compile Include="DispatcherHintShowers\NonVRDispatcherHintShowerFactory.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />

--- a/DVDispatcherMod/DVDispatcherMod.csproj
+++ b/DVDispatcherMod/DVDispatcherMod.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DispatcherHintManagers\NonVRDispatchHintManagerFactory.cs" />
     <Compile Include="DispatcherHints\DispatcherHint.cs" />
     <Compile Include="DispatcherHintShowers\NonVRDispatcherHintShowerFactory.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="HarmonyPatches\FloatieWithAnimation_Start_Patch.cs" />
     <Compile Include="PlayerInteractionManagers\IPlayerInteractionManager.cs" />
     <Compile Include="PlayerInteractionManagers\NonVRPlayerInteractionManager.cs" />

--- a/DVDispatcherMod/DispatcherHintShowers/NonVRDispatcherHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/NonVRDispatcherHintShower.cs
@@ -28,12 +28,12 @@ namespace DVDispatcherMod.DispatcherHintShowers {
             } else {
                 if (_currentlyShowing) {
                     _floatieText.text = dispatcherHintOrNull.Text;
-                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransform;
+                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransformOrNull;
                 } else {
                     _floatie.SetActive(false); // dunno, was in original code like that.
 
                     _floatieText.text = dispatcherHintOrNull.Text;
-                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransform;
+                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransformOrNull;
 
                     _floatie.SetActive(true);
 

--- a/DVDispatcherMod/DispatcherHintShowers/NonVRDispatcherHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/NonVRDispatcherHintShower.cs
@@ -7,6 +7,8 @@ namespace DVDispatcherMod.DispatcherHintShowers {
         private readonly GameObject _floatie;
         private readonly TextMeshProUGUI _floatieText;
         private readonly TutorialLineNonVR _floatieLine;
+        
+        private readonly Transform _attentionLineTransform;
 
         private bool _currentlyShowing;
 
@@ -14,6 +16,10 @@ namespace DVDispatcherMod.DispatcherHintShowers {
             _floatie = floatie;
             _floatieText = floatieText;
             _floatieLine = floatieLine;
+
+            // transforms cannot be instantiated directly, they always live within a game object. thus we create a single (unnecessary) game object and keep it's transform
+            var transformGivingGameObject = new GameObject();
+            _attentionLineTransform = transformGivingGameObject.transform;
         }
 
         public void SetDispatcherHint(DispatcherHint dispatcherHintOrNull) {
@@ -28,17 +34,26 @@ namespace DVDispatcherMod.DispatcherHintShowers {
             } else {
                 if (_currentlyShowing) {
                     _floatieText.text = dispatcherHintOrNull.Text;
-                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransformOrNull;
+                    SetFloatieLineAttentionTransform(dispatcherHintOrNull.AttentionPoint);
                 } else {
                     _floatie.SetActive(false); // dunno, was in original code like that.
 
                     _floatieText.text = dispatcherHintOrNull.Text;
-                    _floatieLine.attentionTransform = dispatcherHintOrNull.AttentionTransformOrNull;
+                    SetFloatieLineAttentionTransform(dispatcherHintOrNull.AttentionPoint);
 
                     _floatie.SetActive(true);
 
                     _currentlyShowing = true;
                 }
+            }
+        }
+
+        private void SetFloatieLineAttentionTransform(Vector3? attentionPoint) {
+            if (attentionPoint == null) {
+                _floatieLine.attentionTransform = null;
+            } else {
+                _attentionLineTransform.position = attentionPoint.Value;
+                _floatieLine.attentionTransform = _attentionLineTransform;
             }
         }
     }

--- a/DVDispatcherMod/DispatcherHintShowers/VRDispatchHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/VRDispatchHintShower.cs
@@ -4,7 +4,15 @@ using VRTK;
 
 namespace DVDispatcherMod.DispatcherHintShowers {
     public class VRDispatchHintShower : IDispatcherHintShower {
-        private static GameObject _floatie;
+        private readonly Transform _attentionLineTransform;
+
+        private GameObject _floatie;
+
+        public VRDispatchHintShower() {
+            // transforms cannot be instantiated directly, they always live within a game object. thus we create a single (unnecessary) game object and keep it's transform
+            var transformGivingGameObject = new GameObject();
+            _attentionLineTransform = transformGivingGameObject.transform;
+        }
 
         public void SetDispatcherHint(DispatcherHint dispatcherHintOrNull) {
             if (dispatcherHintOrNull == null) {
@@ -24,7 +32,11 @@ namespace DVDispatcherMod.DispatcherHintShowers {
                 }
 
                 _floatie.GetComponent<TutorialFloatie>().UpdateTextExternally(dispatcherHintOrNull.Text);
-                _floatie.GetComponent<Floatie>().attentionPoint = dispatcherHintOrNull.AttentionTransformOrNull;
+
+                if (dispatcherHintOrNull.AttentionPoint != null) {
+                    _attentionLineTransform.position = dispatcherHintOrNull.AttentionPoint.Value;
+                    _floatie.GetComponent<Floatie>().attentionPoint = _attentionLineTransform;
+                }
             }
         }
     }

--- a/DVDispatcherMod/DispatcherHintShowers/VRDispatchHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/VRDispatchHintShower.cs
@@ -24,7 +24,7 @@ namespace DVDispatcherMod.DispatcherHintShowers {
                 }
 
                 _floatie.GetComponent<TutorialFloatie>().UpdateTextExternally(dispatcherHintOrNull.Text);
-                _floatie.GetComponent<Floatie>().attentionPoint = dispatcherHintOrNull.AttentionTransform;
+                _floatie.GetComponent<Floatie>().attentionPoint = dispatcherHintOrNull.AttentionTransformOrNull;
             }
         }
     }

--- a/DVDispatcherMod/DispatcherHints/AdjacentCarsCenterFinder.cs
+++ b/DVDispatcherMod/DispatcherHints/AdjacentCarsCenterFinder.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DVDispatcherMod.DispatcherHints {
+    public static class AdjacentCarsCenterFinder {
+        public static Vector3 FindCenter(List<TrainCar> cars) {
+            var carCount = cars.Count;
+            if (carCount == 0) {
+                throw new ArgumentException("cannot get attention point from empty list of cars");
+            } else if ((carCount % 2) == 0) {
+                var car1 = cars[carCount / 2 - 1];
+                var car2 = cars[carCount / 2];
+
+                FindCoupledCouplerPair(car1, car2, out var car1Coupler, out var car2Coupler);
+
+                return Vector3.Lerp(car1Coupler.transform.position, car2Coupler.transform.position, 0.5f);
+            } else {
+                var car = cars[carCount / 2];
+                return Vector3.Lerp(car.frontCoupler.transform.position, car.rearCoupler.transform.position, 0.5f);
+            }
+        }
+
+        private static void FindCoupledCouplerPair(TrainCar car1, TrainCar car2, out Coupler car1Coupler, out Coupler car2Coupler) {
+            if (car1.frontCoupler.coupledTo == car2.frontCoupler) {
+                car1Coupler = car1.frontCoupler;
+                car2Coupler = car2.frontCoupler;
+            } else if (car1.rearCoupler.coupledTo == car2.frontCoupler) {
+                car1Coupler = car1.rearCoupler;
+                car2Coupler = car2.frontCoupler;
+            } else if (car1.frontCoupler.coupledTo == car2.rearCoupler) {
+                car1Coupler = car1.frontCoupler;
+                car2Coupler = car2.rearCoupler;
+            } else if (car1.rearCoupler.coupledTo == car2.rearCoupler) {
+                car1Coupler = car1.rearCoupler;
+                car2Coupler = car2.rearCoupler;
+            } else {
+                throw new InvalidOperationException("could not find common couplers for adjacent cars");
+            }
+        }
+    }
+}

--- a/DVDispatcherMod/DispatcherHints/AdjacentCarsGrouper.cs
+++ b/DVDispatcherMod/DispatcherHints/AdjacentCarsGrouper.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DVDispatcherMod.DispatcherHints {
+    public static class AdjacentCarsGrouper {
+        public static List<List<TrainCar>> GetGroups(IEnumerable<TrainCar> trainCars) {
+            return trainCars.OrderBy(c => c.indexInTrainset).Aggregate(new List<List<TrainCar>>(), AddCarToAdjacencyAggregatedCars);
+        }
+
+        private static List<List<TrainCar>> AddCarToAdjacencyAggregatedCars(List<List<TrainCar>> carGroups, TrainCar trainCar) {
+            if (carGroups.Any()) {
+                var lastCarGrop = carGroups.Last();
+                var lastTrainCar = lastCarGrop.Last();
+                if (lastTrainCar.indexInTrainset + 1 == trainCar.indexInTrainset) {
+                    lastCarGrop.Add(trainCar);
+                    return carGroups;
+                }
+            }
+
+            carGroups.Add(new List<TrainCar> { trainCar });
+
+            return carGroups;
+        }
+    }
+}

--- a/DVDispatcherMod/DispatcherHints/DispatcherHint.cs
+++ b/DVDispatcherMod/DispatcherHints/DispatcherHint.cs
@@ -1,13 +1,14 @@
-﻿using UnityEngine;
+﻿using JetBrains.Annotations;
+using UnityEngine;
 
 namespace DVDispatcherMod.DispatcherHints {
     public class DispatcherHint {
-        public DispatcherHint(string text, Transform attentionTransform) {
+        public DispatcherHint(string text, [CanBeNull] Transform attentionTransformOrNull = null) {
             Text = text;
-            AttentionTransform = attentionTransform;
+            AttentionTransformOrNull = attentionTransformOrNull;
         }
 
         public string Text { get; }
-        public Transform AttentionTransform { get; }
+        [CanBeNull] public Transform AttentionTransformOrNull { get; }
     }
 }

--- a/DVDispatcherMod/DispatcherHints/DispatcherHint.cs
+++ b/DVDispatcherMod/DispatcherHints/DispatcherHint.cs
@@ -3,12 +3,12 @@ using UnityEngine;
 
 namespace DVDispatcherMod.DispatcherHints {
     public class DispatcherHint {
-        public DispatcherHint(string text, [CanBeNull] Transform attentionTransformOrNull = null) {
+        public DispatcherHint(string text, [CanBeNull] Vector3? attentionPoint = null) {
             Text = text;
-            AttentionTransformOrNull = attentionTransformOrNull;
+            AttentionPoint = attentionPoint;
         }
 
         public string Text { get; }
-        [CanBeNull] public Transform AttentionTransformOrNull { get; }
+        [CanBeNull] public Vector3? AttentionPoint { get; }
     }
 }

--- a/DVDispatcherMod/DispatcherHints/JobDispatch.cs
+++ b/DVDispatcherMod/DispatcherHints/JobDispatch.cs
@@ -4,87 +4,144 @@ using System.Linq;
 using System.Text;
 using DV.Logic.Job;
 using DV.ServicePenalty;
+using DVDispatcherMod.Extensions;
 using UnityEngine;
 
 namespace DVDispatcherMod.DispatcherHints {
     public class JobDispatch {
         private readonly Job _job;
+        private readonly IdGenerator _idGenerator;
+        private readonly CareerManagerDebtController _careerManagerDebtController;
+        private readonly PlayerJobs _playerJobs;
 
         public JobDispatch(Job job) {
             _job = job;
+
+            _idGenerator = SingletonBehaviour<IdGenerator>.Instance ?? throw new InvalidOperationException("IdGenerator singleton is null");
+            _careerManagerDebtController = SingletonBehaviour<CareerManagerDebtController>.Instance ?? throw new InvalidOperationException("CareerManagerDebtController singleton is null");
+            _playerJobs = PlayerJobs.Instance ?? throw new InvalidOperationException("PlayerJobs.Instance is nul");
         }
 
         public DispatcherHint GetDispatcherHint(int highlightIndex) {
             if (_job.State == JobState.Completed) {
-                return new DispatcherHint("This job is completed.", null);
+                return new DispatcherHint("This job is completed.");
             } else if (_job.State == JobState.Abandoned) {
-                return new DispatcherHint("This job is abandoned.", null);
+                return new DispatcherHint("This job is abandoned.");
             } else if (_job.State == JobState.Failed) {
-                return new DispatcherHint("This job is failed.", null);
+                return new DispatcherHint("This job is failed.");
             } else if (_job.State == JobState.Expired) {
-                return new DispatcherHint("This job is expired.", null);
+                return new DispatcherHint("This job is expired.");
             }
 
             if (_job.State == JobState.Available) {
                 var jobNotAllowedText = GetJobNotAllowedTextOrNull();
 
                 if (jobNotAllowedText != null) {
-                    return new DispatcherHint(jobNotAllowedText, null);
+                    return new DispatcherHint(jobNotAllowedText);
                 }
             }
 
             var firstUnfinishedTasks = GetFirstUnfinishedTasks(_job.tasks.First());
+            if (!firstUnfinishedTasks.Any()) {
+                return new DispatcherHint("The job is probably complete. Try turning it in.");
+            }
 
-            var carGroupOnTracks = GetCarGroupsOnTracks(firstUnfinishedTasks);
+            var dispatchTrainSets = GetDispatchTrainSets(firstUnfinishedTasks);
 
-            var dispatcherHintText = GetDispatcherHintText(carGroupOnTracks, firstUnfinishedTasks.Any(), highlightIndex);
+            if (!dispatchTrainSets.Any()) {
+                return new DispatcherHint("The job cars could not be found... wtf?");
+            }
 
-            var taskOverview = TaskOverviewGenerator.GetTaskOverview(_job);
-
-            var attentionTransform = GetPointerAt(carGroupOnTracks, highlightIndex);
-
-            var floatieText = dispatcherHintText + Environment.NewLine + taskOverview;
-
-            return new DispatcherHint(floatieText, attentionTransform);
+            return GetDispatcherHintFromDispatchTrainSets(dispatchTrainSets, highlightIndex);
         }
 
         private string GetJobNotAllowedTextOrNull() {
-            if (PlayerJobs.Instance.currentJobs.Count >= LicenseManager.GetNumberOfAllowedConcurrentJobs()) {
+            if (_playerJobs.currentJobs.Count >= LicenseManager.GetNumberOfAllowedConcurrentJobs()) {
                 return "You already have the maximum number of active jobs.";
             } else if (!LicenseManager.IsLicensedForJob(_job.requiredLicenses)) {
                 return "You don't have the required license(s) for this job.";
-            } else if (!SingletonBehaviour<CareerManagerDebtController>.Instance.IsPlayerAllowedToTakeJob()) {
+            } else if (!_careerManagerDebtController.IsPlayerAllowedToTakeJob()) {
                 return "You still have fees to pay off in the Career Manager.";
             } else {
                 return null;
             }
         }
 
-        private static List<CarGroupOnTrack> GetCarGroupsOnTracks(List<Task> carRelevantTasks) {
+        private DispatcherHint GetDispatcherHintFromDispatchTrainSets(List<DispatchTrainSet> dispatchTrainSets, int highlightIndex) {
+            GetHighlightedTrainSetAndCarGroupIndex(highlightIndex, dispatchTrainSets, out var highlightTrainSetIndex, out var highlightCarGroupIndex);
+
+            var dispatcherHintText = GetDispatcherHintTextForAtLeastOneTrainSet(dispatchTrainSets, highlightTrainSetIndex);
+
+            var taskOverview = TaskOverviewGenerator.GetTaskOverview(_job);
+
+            var floatieText = dispatcherHintText + Environment.NewLine + taskOverview;
+
+            var attentionTransform = dispatchTrainSets[highlightTrainSetIndex].CarGroupTransforms[highlightCarGroupIndex];
+
+            return new DispatcherHint(floatieText, attentionTransform);
+        }
+
+        private List<DispatchTrainSet> GetDispatchTrainSets(List<Task> carRelevantTasks) {
             var tasks = carRelevantTasks;
 
             var jobCars = tasks.SelectMany(t => t.GetTaskData().cars).ToList();
 
-            var carGroupsOnTracks =
-                from car in jobCars
-                let trainCar = TryGetTrainCarFromJobCar(car)
-                where trainCar != null
-                group car by trainCar.trainset
-                into trainSetWithCars
-                let trackID = trainSetWithCars.Select(c => c.CurrentTrack?.ID?.TrackPartOnly).FirstOrDefault(id => id != null)
-                let hasLocoHooked = (PlayerManager.LastLoco?.trainset == trainSetWithCars.Key)
-                let consistTransform = trainSetWithCars.Key.cars[trainSetWithCars.Key.cars.Count / 2].transform
-                select new CarGroupOnTrack(trackID, hasLocoHooked, consistTransform);
+            var cars = jobCars.Select(TryGetTrainCarFromJobCar).Where(c => c != null).ToList();
 
-            return carGroupsOnTracks.ToList();
+            var dispatchTrainSets =
+                cars.GroupBy(c => c.trainset)
+                    .Select(g => new DispatchTrainSet(
+                        GetNamedTrackIDFromPreferredCarsOrTrainSet(g.ToList(), g.Key),
+                        IsAnyLocoInConsist(g.Key),
+                        GroupAdjacentCars(g).Select(GetTransformFromAdjacentCars).ToList())
+                    ).ToList();
+
+            return dispatchTrainSets;
         }
 
-        private static TrainCar TryGetTrainCarFromJobCar(Car car) {
-            if (SingletonBehaviour<IdGenerator>.Instance.logicCarToTrainCar.TryGetValue(car, out var trainCar)) {
+        private TrainCar TryGetTrainCarFromJobCar(Car car) {
+            if (_idGenerator.logicCarToTrainCar.TryGetValue(car, out var trainCar)) {
                 return trainCar;
             } else {
                 return null;
             }
+        }
+
+        private static string GetNamedTrackIDFromPreferredCarsOrTrainSet(List<TrainCar> preferredCars, Trainset trainSet) {
+            var preferredCarsTrackID = preferredCars.Select(c => c.logicCar.CurrentTrack?.ID).Where(id => id != null && !id.IsGeneric()).Select(id => id.TrackPartOnly).WhereNotNull().FirstOrDefault();
+            if (preferredCarsTrackID != null) {
+                return preferredCarsTrackID;
+            }
+
+            return trainSet.cars.Select(c => c.logicCar.CurrentTrack?.ID).WhereNotNull().Where(id => !id.IsGeneric()).Select(id => id.TrackPartOnly).WhereNotNull().FirstOrDefault();
+        }
+
+        private static bool IsAnyLocoInConsist(Trainset trainset) {
+            return trainset.cars.Any(c => c.IsLoco);
+        }
+
+        private static List<List<TrainCar>> GroupAdjacentCars(IEnumerable<TrainCar> trainCars) {
+            return trainCars.OrderBy(c => c.indexInTrainset).Aggregate(new List<List<TrainCar>>(), AddCarToAdjacencyAggregatedCars);
+        }
+
+        private static List<List<TrainCar>> AddCarToAdjacencyAggregatedCars(List<List<TrainCar>> carGroups, TrainCar trainCar) {
+            if (carGroups.Any()) {
+                var lastCarGrop = carGroups.Last();
+                var lastTrainCar = lastCarGrop.Last();
+                if (lastTrainCar.indexInTrainset + 1 == trainCar.indexInTrainset) {
+                    lastCarGrop.Add(trainCar);
+                    return carGroups;
+                }
+            }
+
+            carGroups.Add(new List<TrainCar> { trainCar });
+
+            return carGroups;
+        }
+
+        private static Transform GetTransformFromAdjacentCars(List<TrainCar> cars) {
+            // it would be nice if we could point to the middle of the 2 center cars in case the number of cars is even
+            return cars[cars.Count / 2].transform;
         }
 
         /// <summary>
@@ -118,68 +175,89 @@ namespace DVDispatcherMod.DispatcherHints {
             return toReturn;
         }
 
-        private string GetDispatcherHintText(List<CarGroupOnTrack> carGroupsOnTracks, bool hasAnyUnfinishedTask, int highlightIndex) {
-            if (carGroupsOnTracks.Count > 0) {
-                return GetDispatcherHintTextForAtLeastOneCarGroup(carGroupsOnTracks, highlightIndex);
-            } else if (!hasAnyUnfinishedTask) {
-                return "The job is probably complete. Try turning it in.";
+        private string GetDispatcherHintTextForAtLeastOneTrainSet(List<DispatchTrainSet> dispatchTrainSets, int highlightTrainSetIndex) {
+            if (dispatchTrainSets.Count == 1) {
+                var dispatchTrainSet = dispatchTrainSets[0];
+                var sb = new StringBuilder($"The cars for job {_job.ID} are in the same consist");
+                var carGroupCount = dispatchTrainSet.CarGroupTransforms.Count;
+                if (carGroupCount > 1) {
+                    sb.Append($" (but in {carGroupCount} distinct car groups)");
+                }
+                if (dispatchTrainSet.TrackIDOrNull != null) {
+                    sb.Append($" on track <color=#F29839>{dispatchTrainSet.TrackIDOrNull}</color>");
+                }
+                if (dispatchTrainSet.HasLocoHooked) {
+                    sb.Append(" and have a locomotive attached");
+                }
+                sb.Append(".");
+                return sb.ToString();
             } else {
-                return "The job cars could not be found... wtf?";
-            }
-        }
+                var sb = new StringBuilder($"The cars for job {_job.ID} are currently in {dispatchTrainSets.Count} different consists");
 
-        private string GetDispatcherHintTextForAtLeastOneCarGroup(List<CarGroupOnTrack> carGroupsOnTracks, int highlightIndex) {
-            if (carGroupsOnTracks.Count == 1) {
-                var carGroupOnTrack = carGroupsOnTracks[0];
-                return $"The cars for job {_job.ID} are in the same consist on track <color=#F29839>{(carGroupOnTrack == null ? "(Unknown)" : carGroupOnTrack.TrackID)}</color>{(carGroupOnTrack.HasLastPlayerLocoHooked ? " and have a locomotive attached" : "")}.";
-            } else {
-                highlightIndex %= carGroupsOnTracks.Count;
-                var sb = new StringBuilder($"The cars for job {_job.ID} are currently in {carGroupsOnTracks.Count} different consists on tracks");
-                for (var i = 0; i < carGroupsOnTracks.Count; i++) {
-                    if (i > 0 && carGroupsOnTracks.Count > 2) {
-                        sb.Append(',');
+                var namedTracksWithHighlights = dispatchTrainSets.Select((s, i) => new { s.TrackIDOrNull, IsHighlighted = (i == highlightTrainSetIndex) }).Where(t => t.TrackIDOrNull != null).GroupBy(t => t.TrackIDOrNull, (key, values) => new { Track = key, IsHighlighted = values.Any(t => t.IsHighlighted) }).ToList();
+
+                if (namedTracksWithHighlights.Any()) {
+                    // there is at least one track with a meaningful name
+                    if (dispatchTrainSets.Any(d => d.TrackIDOrNull == null)) {
+                        sb.Append(", some");
                     }
-                    if (i == carGroupsOnTracks.Count - 1) {
-                        sb.Append(" and");
-                    }
-                    sb.Append(' ');
-                    var carGroupOnTrack = carGroupsOnTracks[i];
-                    if (i == highlightIndex) {
-                        sb.AppendFormat("<color=#F29839>{0}</color>", carGroupOnTrack == null ? "(Unknown)" : carGroupOnTrack.TrackID);
+
+                    if (namedTracksWithHighlights.Count == 1) {
+                        sb.Append(" on track ");
                     } else {
-                        sb.Append(carGroupOnTrack == null ? "(Unknown)" : carGroupOnTrack.TrackID);
+                        sb.Append(" on tracks ");
+                    }
+                    for (var i = 0; i < namedTracksWithHighlights.Count; i++) {
+                        if (namedTracksWithHighlights[i].IsHighlighted) {
+                            sb.Append("<color=#F29839>");
+                            sb.Append(namedTracksWithHighlights[i].Track);
+                            sb.Append("</color>");
+                        } else {
+                            sb.Append(namedTracksWithHighlights[i].Track);
+                        }
+                        if (i < namedTracksWithHighlights.Count - 2) {
+                            sb.Append(", ");
+                        } else if (i < namedTracksWithHighlights.Count - 1) {
+                            sb.Append(" and ");
+                        }
                     }
                 }
+
                 sb.Append('.');
                 return sb.ToString();
             }
         }
 
-        private static Transform GetPointerAt(List<CarGroupOnTrack> carGroupsOnTracks, int index) {
-            if (!carGroupsOnTracks.Any()) {
-                return null;
+        private void GetHighlightedTrainSetAndCarGroupIndex(int unboundedHighlightIndex, List<DispatchTrainSet> dispatchTrainSets, out int trainSetIndex, out int carGroupIndex) {
+            var highlightIndex = unboundedHighlightIndex % dispatchTrainSets.Sum(t => t.CarGroupTransforms.Count);
+
+            int currentIndex = 0;
+            for (var currentTrainSetIndex = 0; currentTrainSetIndex < dispatchTrainSets.Count; currentTrainSetIndex += 1) {
+                var currentTrainSet = dispatchTrainSets[currentTrainSetIndex];
+                for (var currentCarGroupIndex = 0; currentCarGroupIndex < currentTrainSet.CarGroupTransforms.Count; currentCarGroupIndex += 1) {
+                    if (currentIndex == highlightIndex) {
+                        trainSetIndex = currentTrainSetIndex;
+                        carGroupIndex = currentCarGroupIndex;
+                        return;
+                    }
+
+                    currentIndex++;
+                }
             }
 
-            index %= carGroupsOnTracks.Count;
-            var carGroupOnTrack = carGroupsOnTracks[index];
-            if (carGroupOnTrack.HasLastPlayerLocoHooked) {
-                return PlayerManager.LastLoco?.transform;
-            }
-
-            // TODO: Raise pointer to middle of car height.
-            return carGroupOnTrack.ConsistTransform;
+            throw new InvalidOperationException("could not determine train set and car group index");
         }
 
-        private class CarGroupOnTrack {
-            public string TrackID { get; }
-            public bool HasLastPlayerLocoHooked { get; }
-            public Transform ConsistTransform { get; }
-
-            public CarGroupOnTrack(string trackID, bool hasLastPlayerLocoHooked, Transform consistTransform) {
-                TrackID = trackID;
-                HasLastPlayerLocoHooked = hasLastPlayerLocoHooked;
-                ConsistTransform = consistTransform;
+        private class DispatchTrainSet {
+            public DispatchTrainSet(string trackIDOrNull, bool hasLocoHooked, List<Transform> carGroupTransforms) {
+                TrackIDOrNull = trackIDOrNull;
+                HasLocoHooked = hasLocoHooked;
+                CarGroupTransforms = carGroupTransforms;
             }
+
+            public string TrackIDOrNull { get; }
+            public bool HasLocoHooked { get; }
+            public List<Transform> CarGroupTransforms { get; }
         }
     }
 }

--- a/DVDispatcherMod/Extensions/EnumerableExtensions.cs
+++ b/DVDispatcherMod/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DVDispatcherMod.Extensions {
+    public static class EnumerableExtensions {
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> enumerable) where T : class {
+            return enumerable.Where(item => item != null);
+        }
+    }
+}


### PR DESCRIPTION
Examples follow. Screenshots were taken before raising attention point.

Cars in same consist but not adjacent.
![20220827002004_1](https://user-images.githubusercontent.com/8106744/187095149-13078b79-7b57-40a8-9258-9a54532f9e2b.jpg)

Cars in multiple consists, some not on a named track. The pointer cycles between all car groups, but only named tracks are highlighted in orange.
![20220827165713_1](https://user-images.githubusercontent.com/8106744/187095200-c6c07849-0d74-48f3-8538-b723193703b7.jpg)

Cars in multiple consists, all of them named.
![20220827170005_1](https://user-images.githubusercontent.com/8106744/187095252-edd380fb-dab7-4dc8-9c3e-7ee67420e278.jpg)

None of the consists on a named track. No track information is given.
![20220827170438_1](https://user-images.githubusercontent.com/8106744/187095273-a06cf690-bcb0-4277-a5f0-e5264c41ff74.jpg)